### PR TITLE
higher postgres version - to fix security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.6.0</version>
+			<version>42.7.5</version>
 		</dependency>
 
 		<!--Session -->


### PR DESCRIPTION
Only change here -> updated Postgres Dependency from 42.6.0 to 42.7.5 to fix security issues (infomdes by github security about high vunerability due to sql injection risk for the 42.6.0 version 